### PR TITLE
Improve scrolling behavior

### DIFF
--- a/src/Charts/ChartsContainer.js
+++ b/src/Charts/ChartsContainer.js
@@ -37,13 +37,12 @@ export class ChartsContainer extends React.Component { // eslint-disable-line re
       <div
         className="charts-container"
         style={{
+          overflow: 'hidden',
           display: 'flex',
           flexWrap: 'wrap',
-          flexGrow: '1',
-          flexShrink: '1',
-          overflow: 'hidden',
-          border: '2px solid blue',
-          justifyContent: 'center',
+          justifyContent: 'space-around',
+          alignItems: 'stretch',
+          alignContent: 'stretch',
         }}
       >
         {charts.map((chart, idx) => (
@@ -65,3 +64,4 @@ const stateToProps = (state: TApplicationState) => ({
 });
 
 export default connect(stateToProps)(Radium(ChartsContainer));
+

--- a/src/Charts/ChartsContainer.test.js
+++ b/src/Charts/ChartsContainer.test.js
@@ -9,7 +9,7 @@ import {
   MoodWithEntries,
   BurnsWithoutEntries,
 } from '../../test/SampleMetrics';
-import { LINE_COLORS } from './constants';
+import { LINE_COLORS, MS_PER_PX } from './constants';
 
 import { ChartsContainer } from './ChartsContainer';
 import Chart from './components/Chart';
@@ -42,8 +42,12 @@ describe('ChartsContainer', () => {
             mode: 'on',
             color: LINE_COLORS[MoodWithEntries.id % LINE_COLORS.length],
           }],
-          zoomFactor: 1,
-          viewCenter: +moment('2012-02-02T23:42'),
+          dateRange: [
+            +moment('2012-01-02T23:42'),
+            +moment('2012-04-01T23:42'),
+          ],
+          viewCenter: +moment('2012-02-02T23:23'),
+          msPerPx: MS_PER_PX,
         }, {
           id: 2,
           lines: [{
@@ -51,8 +55,12 @@ describe('ChartsContainer', () => {
             mode: 'on',
             color: LINE_COLORS[BurnsWithoutEntries.id % LINE_COLORS.length],
           }],
-          zoomFactor: 1,
-          viewCenter: +moment('2015-02-05T23:11'),
+          dateRange: [
+            +moment('2015-01-02T23:42'),
+            +moment('2015-04-01T23:42'),
+          ],
+          viewCenter: +moment('2015-02-02T23:42'),
+          msPerPx: MS_PER_PX,
         }]}
         dispatch={jest.fn()}
       />);

--- a/src/Charts/actionTypes.js
+++ b/src/Charts/actionTypes.js
@@ -1,20 +1,73 @@
 /* @flow */
+/* TODO add docs */
 import type { TMetric } from '../types';
 
-export type TDefaultAction = { type: 'charts/DEFAULT_ACTION' };
-export type TRequestZoomAction = { type: 'charts/REQUEST_ZOOM', chartId: number, zoomFactor: number };
-export type TBeginZoomAction = { type: 'charts/BEGIN_ZOOM', chartId: number, finishTime: number, targetZoomFactor: number };
-export type TSetZoomFactorAction = { type: 'charts/SET_ZOOM_FACTOR', chartId: number, zoomFactor: number };
-export type TFinishZoomAction = { type: 'charts/FINISH_ZOOM', chartId: number };
-export type TCycleModeAction = { type: 'charts/CYCLE_MODE', metricId: number };
-export type TScrollByAction = { type: 'charts/SCROLL_BY', chartId: number, deltaX: number };
-export type TCreateChartsAction = { type: 'charts/CREATE_CHARTS', metrics: TMetric[] };
+export type TDefaultAction = {
+  type: 'charts/DEFAULT_ACTION',
+};
 
-export type TChartsAction =
-    TDefaultAction
+/**
+ * Request-zoom action.
+ *
+ * Triggered by UI events like the user clicking
+ * on one of the zoom buttons in a chart.
+ */
+export type TRequestZoomAction = {
+  type: 'charts/REQUEST_ZOOM',
+
+  /**
+   * The id of the selected chart
+   */
+  chartId: number,
+
+  /**
+   * The (relative) zoom factor
+   *
+   * Numbers greater than 1 magnify,
+   * numbers less than 1 zoom out.
+   */
+  factor: number,
+};
+
+export type TBeginZoomAction = {
+  type: 'charts/BEGIN_ZOOM',
+  chartId: number,
+  finishTime: number,
+  targetMsPerPx: number,
+};
+
+export type TSetMsPerPxAction = {
+  type: 'charts/SET_MS_PER_PX',
+  chartId: number,
+  msPerPx: number,
+};
+
+export type TFinishZoomAction = {
+  type: 'charts/FINISH_ZOOM',
+  chartId: number,
+};
+
+export type TCycleModeAction = {
+  type: 'charts/CYCLE_MODE',
+  metricId: number
+};
+
+export type TScrollByAction = {
+  type: 'charts/SCROLL_BY',
+  chartId: number,
+  deltaX: number
+};
+
+export type TCreateChartsAction = {
+  type: 'charts/CREATE_CHARTS',
+  metrics: TMetric[]
+};
+
+export type TChartsAction
+  = TDefaultAction
   | TRequestZoomAction
   | TBeginZoomAction
-  | TSetZoomFactorAction
+  | TSetMsPerPxAction
   | TFinishZoomAction
   | TCycleModeAction
   | TScrollByAction

--- a/src/Charts/actions.js
+++ b/src/Charts/actions.js
@@ -3,7 +3,7 @@ import type {
   TDefaultAction,
   TRequestZoomAction,
   TBeginZoomAction,
-  TSetZoomFactorAction,
+  TSetMsPerPxAction,
   TFinishZoomAction,
   TCycleModeAction,
   TScrollByAction,
@@ -19,16 +19,16 @@ export function defaultAction(): TDefaultAction {
  * Request to begin animating the zoom-level of a chart.
  * The zoomFactor parameter is relative to the current zoom-level.
  */
-export function requestZoom(chartId: number, zoomFactor: number = 1): TRequestZoomAction {
-  return { type: 'charts/REQUEST_ZOOM', chartId, zoomFactor };
+export function requestZoom(chartId: number, factor: number = 1): TRequestZoomAction {
+  return { type: 'charts/REQUEST_ZOOM', chartId, factor };
 }
 
-export function beginZoom(chartId: number, finishTime: number, targetZoomFactor: number): TBeginZoomAction {
-  return { type: 'charts/BEGIN_ZOOM', chartId, finishTime, targetZoomFactor };
+export function beginZoom(chartId: number, finishTime: number, targetMsPerPx: number): TBeginZoomAction {
+  return { type: 'charts/BEGIN_ZOOM', chartId, finishTime, targetMsPerPx };
 }
 
-export function setZoomFactor(chartId: number, zoomFactor: number): TSetZoomFactorAction {
-  return { type: 'charts/SET_ZOOM_FACTOR', chartId, zoomFactor };
+export function setMsPerPx(chartId: number, msPerPx: number): TSetMsPerPxAction {
+  return { type: 'charts/SET_MS_PER_PX', chartId, msPerPx };
 }
 
 export function finishZoom(chartId: number): TFinishZoomAction {
@@ -46,3 +46,4 @@ export function scrollBy(chartId: number, deltaX: number): TScrollByAction {
 export function createCharts(metrics: TMetric[]): TCreateChartsAction {
   return { type: 'charts/CREATE_CHARTS', metrics };
 }
+

--- a/src/Charts/components/Axis.js
+++ b/src/Charts/components/Axis.js
@@ -1,9 +1,13 @@
 /* @flow */
 import React from 'react';
+import Radium from 'radium';
 import Line from './Line';
 import type { TDimensions, TAxisTick, TChartPadding } from '../types';
 
 const axisColor = '#fff';
+const labelStyle = {
+  fontSize: '10px',
+};
 
 type TAxisProps = {
   /**
@@ -41,7 +45,18 @@ export const XAxis = ({ dimensions, ticks, padding }: TAxisProps) => (
           color={axisColor}
           className="axis-tick"
         />
-        <text textAnchor="middle" alignmentBaseline="baseline" x={tick.position} y={dimensions.height - (padding.bottom || 0)}>{tick.label}</text>
+        <text
+          textAnchor="middle"
+          alignmentBaseline="hanging"
+          x={tick.position}
+          y={dimensions.height - (padding.bottom || 0)}
+          style={{
+            zIndex: '100',
+            ...labelStyle,
+          }}
+        >
+          {tick.label}
+        </text>
       </g>
     ))}
   </g>
@@ -71,7 +86,11 @@ export const YAxis = ({ dimensions, ticks, padding }: TAxisProps) => (
           x={5}
           y={tick.position}
           textAnchor="left"
-          alignmentBaseline="hanging"
+          alignmentBaseline="middle"
+          style={{
+            zIndex: '100',
+            ...labelStyle,
+          }}
         >
           {tick.label}
         </text>
@@ -84,5 +103,5 @@ YAxis.defaultProps = { vertical: true };
 const Axis = (props: TAxisProps) => (props.vertical === false ? <XAxis {...props} /> : <YAxis {...props} />);
 Axis.defaultProps = { vertical: false };
 
-export default Axis;
+export default Radium(Axis);
 

--- a/src/Charts/components/Chart.js
+++ b/src/Charts/components/Chart.js
@@ -70,9 +70,8 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
       style={{
         height: '200px',
         overflow: 'hidden',
-        minWidth: '200px',
-        maxWidth: '600px',
-        margin: '32px',
+        width: '100%',
+        position: 'relative',
       }}
     >
       <div className="chart-buttons">
@@ -142,10 +141,20 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
 };
 
 export default Radium((props: TChartProps) => (
-  <Measure>
-    {(dimensions: TDimensions) => (
-      <ChartMeasured metrics={props.metrics} chart={props.chart} dispatch={props.dispatch} dimensions={dimensions} />
-    )}
-  </Measure>
+  <div
+    className="outer-chart-container"
+    style={{
+      margin: '16px',
+      maxWidth: '500px',
+      minWidth: '200px',
+      flexGrow: '1',
+    }}
+  >
+    <Measure>
+      {(dimensions: TDimensions) => (
+        <ChartMeasured metrics={props.metrics} chart={props.chart} dispatch={props.dispatch} dimensions={dimensions} />
+      )}
+    </Measure>
+  </div>
 ));
 

--- a/src/Charts/components/Chart.js
+++ b/src/Charts/components/Chart.js
@@ -68,25 +68,32 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
       className="chart"
       onWheel={handleWheel}
       style={{
-        height: '200px',
+        height: '240px',
         overflow: 'hidden',
         width: '100%',
         position: 'relative',
+        borderRadius: '4',
+        border: '1px solid #dadada',
+        boxShadow: '0px 1px 0px rgba(0, 0, 0, 0.1)',
       }}
     >
-      <div className="chart-buttons">
+      <div
+        className="chart-buttons pt-button-group"
+        style={{
+          position: 'absolute',
+          top: '8px',
+          right: '8px',
+          zIndex: '10',
+        }}
+      >
         <Button
           onClick={() => dispatch(requestZoom(chart.id, 1.2))}
-          className="chart-zoom-in-button"
-        >
-          +
-        </Button>
+          className="chart-zoom-in-button pt-icon-small-plus"
+        />
         <Button
           onClick={() => dispatch(requestZoom(chart.id, 0.8))}
-          className="chart-zoom-out-button"
-        >
-          –
-        </Button>
+          className="chart-zoom-out-button pt-icon-small-minus"
+        />
       </div>
       <Draggable onDrag={(event: Event, data: DraggableData) => dispatch(scrollBy(chart.id, -data.deltaX))}>
         <svg
@@ -94,6 +101,7 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
           style={{
             width: dimensions.width,
             height: dimensions.height,
+            backgroundColor: '#f2f5f8',
           }}
         >
           <ChartGrid
@@ -145,7 +153,7 @@ export default Radium((props: TChartProps) => (
     className="outer-chart-container"
     style={{
       margin: '16px',
-      maxWidth: '500px',
+      maxWidth: '600px',
       minWidth: '200px',
       flexGrow: '1',
     }}

--- a/src/Charts/components/Chart.js
+++ b/src/Charts/components/Chart.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { min, max, map, flow, slice, findIndex, findLastIndex } from 'lodash/fp';
 import { Button } from '@blueprintjs/core';
 import ScrollBar from './ScrollBar';
-import { FOUR_WEEKS, LINE_COLORS, CHART_PADDING } from '../constants';
+import { LINE_COLORS, CHART_PADDING } from '../constants';
 import Line from './Line';
 import ChartGrid from './ChartGrid';
 import Legend from './Legend';
@@ -61,8 +61,8 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
 
   const dateRangeBegin: number = min(metrics.map(m => +moment(m.entries[0].date)));
   const dateRangeEnd: number = max(metrics.map(m => +moment(m.entries[m.entries.length - 1].date)));
-  const viewRangeBegin: number = chart.viewCenter - (FOUR_WEEKS / chart.zoomFactor);
-  const viewRangeEnd: number = chart.viewCenter + (FOUR_WEEKS / chart.zoomFactor);
+  const viewRangeBegin: number = chart.viewCenter - ((dimensions.width * chart.msPerPx) / 2);
+  const viewRangeEnd: number = chart.viewCenter + ((dimensions.width * chart.msPerPx) / 2);
   return (
     <div
       className="chart"

--- a/src/Charts/components/Chart.js
+++ b/src/Charts/components/Chart.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { min, max, map, flow, slice, findIndex, findLastIndex } from 'lodash/fp';
 import { Button } from '@blueprintjs/core';
 import ScrollBar from './ScrollBar';
-import { FOUR_WEEKS, LINE_COLORS } from '../constants';
+import { FOUR_WEEKS, LINE_COLORS, CHART_PADDING } from '../constants';
 import Line from './Line';
 import ChartGrid from './ChartGrid';
 import Legend from './Legend';
@@ -101,15 +101,15 @@ export const ChartMeasured = ({ metrics, chart, dispatch, dimensions }: TChartPr
             dateRange={[viewRangeBegin, viewRangeEnd]}
             dimensions={dimensions}
             valueRange={[metrics[0].props.minValue, metrics[0].props.maxValue]}
-            padding={{ bottom: 20 }}
+            padding={CHART_PADDING}
           />
           {map((metric: TMetric) => (
             <Line
               key={metric.id}
               points={flow(
                 map((entry: TMetricEntry) => ({
-                  x: xValueToPixels(+moment(entry.date), [viewRangeBegin, viewRangeEnd], dimensions.width, { bottom: 20 }),
-                  y: yValueToPixels(entry.value, [metric.props.minValue, metric.props.maxValue], dimensions.height, { bottom: 20 }),
+                  x: xValueToPixels(+moment(entry.date), [viewRangeBegin, viewRangeEnd], dimensions.width, CHART_PADDING),
+                  y: yValueToPixels(entry.value, [metric.props.minValue, metric.props.maxValue], dimensions.height, CHART_PADDING),
                 })),
                 (ary: TLinePoint[]) => slice(
                   max([findLastIndex(item => item.x < 0)(ary), 0]),

--- a/src/Charts/components/ChartGrid.js
+++ b/src/Charts/components/ChartGrid.js
@@ -5,6 +5,7 @@ import type { TColorGroup } from '../../types';
 import type { TChartPadding, TDimensions, TRange } from '../types';
 import Axis from './Axis';
 import { getXAxisTicks, getYAxisTicks, yValueToPixels } from '../svg-utils';
+import { CHART_PADDING } from '../constants';
 
 type TColorGroupRectProps = {
   colorGroup: TColorGroup,
@@ -66,19 +67,19 @@ const ChartGrid = ({ dimensions, dateRange, valueRange, colorGroups }: TChartGri
         dimensions={dimensions}
         valueRange={valueRange}
         colorGroup={colorGroup}
-        padding={{ bottom: 20 }}
+        padding={CHART_PADDING}
       />
     ))}
     <Axis
-      vertical
       dimensions={dimensions}
-      ticks={getYAxisTicks(dimensions.height, valueRange, { bottom: 20 })}
-      padding={{ bottom: 20 }}
+      ticks={getXAxisTicks(dimensions.width, dateRange, CHART_PADDING)}
+      padding={CHART_PADDING}
     />
     <Axis
+      vertical
       dimensions={dimensions}
-      ticks={getXAxisTicks(dimensions.width, dateRange, { bottom: 20 })}
-      padding={{ bottom: 20 }}
+      ticks={getYAxisTicks(dimensions.height, valueRange, CHART_PADDING)}
+      padding={CHART_PADDING}
     />
   </g>
 );

--- a/src/Charts/components/ChartGrid.test.js
+++ b/src/Charts/components/ChartGrid.test.js
@@ -1,6 +1,7 @@
 /* @flow */
 /* eslint-env jest */
 /* eslint-disable no-unused-expressions */
+/* TODO Find out why the axis lines are broken */
 import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';

--- a/src/Charts/components/ScrollBar.js
+++ b/src/Charts/components/ScrollBar.js
@@ -31,26 +31,32 @@ const ScrollBar = ({ width, viewRange, dateRange, scrollBy }: TScrollBarProps) =
     style={{
       display: 'block',
       width: '100%',
-      height: '1ex',
+      height: '8px',
       backgroundColor: '#eee',
       overflow: 'hidden',
+      zIndex: '5',
+      position: 'absolute',
+      bottom: '0px',
     }}
   >
     <Draggable
       axis="x"
       onDrag={(event: Event, data: DraggableData) => scrollBy(data.deltaX)}
       position={{
-        x: ((viewRange[0] - dateRange[0]) / (dateRange[1] - dateRange[0])) * width,
+        x: 0,
         y: 0,
       }}
     >
       <div
         className="chart-scrollbar"
         style={{
+          left: ((viewRange[0] - dateRange[0]) / (dateRange[1] - dateRange[0])) * width,
           display: 'block',
           position: 'relative',
-          height: '100%',
-          backgroundColor: 'grey',
+          height: '5px',
+          margin: 'auto 0px',
+          borderRadius: '4px',
+          backgroundColor: '#AAA',
           width: `${((viewRange[1] - viewRange[0]) / (dateRange[1] - dateRange[0])) * width}px`,
         }}
       />
@@ -59,3 +65,4 @@ const ScrollBar = ({ width, viewRange, dateRange, scrollBy }: TScrollBarProps) =
 );
 
 export default Radium(ScrollBar);
+

--- a/src/Charts/constants.js
+++ b/src/Charts/constants.js
@@ -1,4 +1,5 @@
 /* @flow */
+import type { TChartPadding } from './types';
 
 export const FOUR_WEEKS: number = 2.4e8;
 export const MS_PER_PX: number = FOUR_WEEKS / 400;
@@ -8,3 +9,9 @@ export const LINE_COLORS: string[] = [
   '#C46C8C',
   '#E1BE7C',
 ];
+export const CHART_PADDING: TChartPadding = {
+  top: 4,
+  left: 5,
+  right: 5,
+  bottom: 20,
+};

--- a/src/Charts/constants.js
+++ b/src/Charts/constants.js
@@ -4,14 +4,16 @@ import type { TChartPadding } from './types';
 export const FOUR_WEEKS: number = 2.4e8;
 export const MS_PER_PX: number = FOUR_WEEKS / 400;
 export const LINE_COLORS: string[] = [
-  '#596E96',
-  '#C8D978',
-  '#C46C8C',
-  '#E1BE7C',
+  '#801515',
+  '#152C55',
+  '#797E15',
+  '#805B15',
+  '#391356',
+  '#10621E',
 ];
 export const CHART_PADDING: TChartPadding = {
-  top: 4,
-  left: 5,
-  right: 5,
-  bottom: 20,
+  top: 10,
+  left: 10,
+  right: 10,
+  bottom: 24,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,6 @@
 // @flow
 import type { TAction } from './actionTypes';
+import type { TRange } from './Charts/types';
 
 export type TChartLine = {
   +metricId: number,
@@ -12,13 +13,14 @@ export type TChart = {
   +lines: TChartLine[];
   +animation?: {
     +target: {
-      +zoomFactor?: number,
+      +msPerPx?: number,
       +viewCenter?: number,
     },
     +finishTime: number,
   },
-  +zoomFactor: number,
   +viewCenter: number,
+  +msPerPx: number,
+  +dateRange: TRange,
 };
 
 export type TMetricType = 'int';


### PR DESCRIPTION
I made the chart state use ms/px as the measure for the zoom level. Also, I added a `dateRange` property to the chart state so I can prevent scrolling past the edges.

These changes are causing some issues to the graph rendering and make grid lines disappear.