### PR TITLE
Prevent errors in tests that include Radium

### DIFF
--- a/src/AppContainer/App.js
+++ b/src/AppContainer/App.js
@@ -86,5 +86,6 @@ const stateToProps = (state: TApplicationState) => ({
   metrics: state.metrics,
 });
 
-export default connect(stateToProps)(Radium(App));
+export const ConnectedApp = connect(stateToProps)(App);
+export default Radium(ConnectedApp);
 

--- a/src/AppContainer/App.test.js
+++ b/src/AppContainer/App.test.js
@@ -15,7 +15,7 @@ import {
 
 import type { TApplicationState } from '../types';
 
-import ConnectedApp, { App } from './App';
+import { App, ConnectedApp } from './App';
 import LoginScreen from '../components/LoginScreen';
 
 const mockStore = configureMockStore();

--- a/src/Charts/ChartsContainer.js
+++ b/src/Charts/ChartsContainer.js
@@ -63,5 +63,6 @@ const stateToProps = (state: TApplicationState) => ({
   charts: state.charts,
 });
 
-export default connect(stateToProps)(Radium(ChartsContainer));
+export const ConnectedComponent = connect(stateToProps)(ChartsContainer);
+export default Radium(ConnectedComponent);
 


### PR DESCRIPTION
Components that are implemented using the ES6 `class` keyword don't work with Radium+Jest, so I'm exporting versions that don't wrap Radium.